### PR TITLE
Add option to do a signed push

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -95,6 +95,11 @@
   :group 'magit-gerrit
   :type 'key-sequence)
 
+(defcustom magit-gerrit-signed-push-p nil
+  "Whether or not to push with the --signed option."
+  :group 'magit-gerrit
+  :type 'boolean)
+
 (defun gerrit-command (cmd &rest args)
   (let ((gcmd (concat
 	       "-x -p 29418 "
@@ -465,7 +470,7 @@ Succeed even if branch already exist
 		(string= branch-remote "."))
 	(setq branch-remote magit-gerrit-remote))
 
-      (magit-run-git-async "push" "-v" branch-remote
+      (magit-run-git-async "push" "-v" (when magit-gerrit-signed-push-p "--signed") branch-remote
 			   (concat rev ":" branch-pub)))))
 
 (defun magit-gerrit-create-review ()


### PR DESCRIPTION
A push with a `--signed` option allows gerrit to verify
the owner of the change.
See https://www.gerritcodereview.com/2.12.html#gpg-keys-and-signed-pushes
and https://gerrit-documentation.storage.googleapis.com/Documentation/2.12/config-gerrit.html#receive.enableSignedPush