### PR TITLE
Add possibility to fetch only watched reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Then:
 
 ;; if necessary, use an alternative remote instead of 'origin'
 (setq-default magit-gerrit-remote "gerrit")  
+
+;; if your remote contains too much reviews, itcan become slow,
+;; and you can choose to fetch only your watched reviews.
+(setq-default magit-gerrit-extra-options "is:watched is:owner")
 ```
 
 

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -93,6 +93,11 @@
   :group 'magit-gerrit
   :type 'boolean)
 
+(defcustom magit-gerrit-extra-options nil
+  "Extra options defined when fetching reviews"
+  :group 'magit-gerrit
+  :type 'string)
+
 (defun gerrit-command (cmd &rest args)
   (let ((gcmd (concat
 	       "-x -p 29418 "
@@ -113,6 +118,7 @@
 		  "--comments"
 		  "--current-patch-set"
 		  (concat "project:" prj)
+		  (concat magit-gerrit-extra-options)
 		  (concat "status:" (or status "open"))))
 
 (defun gerrit-review ())


### PR DESCRIPTION
Are you interested in this little improvement?

The idea is to let the user choose between fetching all reviews or only the ones he's watching, to limit fetching time in case of repositories with high number of reviews.