### PR TITLE
Fix magit-gerrit-section output over Tramp

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -420,6 +420,7 @@ Succeed even if branch already exist
 
 (defun magit-gerrit-section (_section title washer &rest args)
   (let ((magit-git-executable "ssh")
+        (magit-remote-git-executable "ssh")
         (magit-git-global-arguments nil))
     (magit-insert-section (section title)
       (magit-insert-heading title)


### PR DESCRIPTION
Make magit-gerrit review section output work over Tramp. Remote mode uses 'magit-remote-git-executable' which defaults to 'git'. This caused gerrit command to fail and 'Reviews' section was never displayed.