### PR TITLE
Add possibility to select remote URL source

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ Then:
 (setq-default magit-gerrit-ssh-creds "myid@gerrithost.org")
 
 ;; if necessary, use an alternative remote instead of 'origin'
-(setq-default magit-gerrit-remote "gerrit")  
+(setq-default magit-gerrit-remote "gerrit")
 
 ;; if your remote contains too much reviews, itcan become slow,
 ;; and you can choose to fetch only your watched reviews.
 (setq-default magit-gerrit-extra-options "is:watched is:owner")
+
+;; if you have separate servers for push and pull access
+;; you can select push URL by setting magit-gerrit-use-push-url
+(setq-default magit-gerrit-use-push-url t)
 
 ;; display review label header, off by default
 (setq-default magit-gerrit-show-review-labels t)
@@ -54,7 +58,7 @@ Workflow
 Magit Gerrit Configuration
 --------------------------
 
-For simple setups, it should be enough to set the default value for 
+For simple setups, it should be enough to set the default value for
 `magit-gerrit-ssh-creds` and `magit-gerrit-remote` as shown above.
 
 For per project configurations, consider using buffer local or directory local

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -83,6 +83,11 @@
 (defvar-local magit-gerrit-remote "origin"
   "Default remote name to use for gerrit (e.g. \"origin\", \"gerrit\")")
 
+(defcustom magit-gerrit-use-push-url nil
+  "If t use push url from 'git remote' for Gerrit connection."
+  :group 'magit-gerrit
+  :type 'boolean)
+
 (defcustom magit-gerrit-show-review-labels nil
   "If t show Gerrit Review Labels as 1st row."
   :group 'magit-gerrit
@@ -161,8 +166,15 @@
   (gerrit-ssh-cmd "review" "--project" prj "--verified" score
                   (if msg msg "") rev))
 
+(defun magit-gerrit-select-remote-url-cmd ()
+  "Returns git command to be used to resolve remote URL."
+  (if magit-gerrit-use-push-url
+      (list "remote" "get-url" "--push")
+    (list "ls-remote" "--get-url")))
+
 (defun magit-gerrit-get-remote-url ()
-  (magit-git-string "ls-remote" "--get-url" magit-gerrit-remote))
+  "Returns remote URL."
+  (magit-git-string (magit-gerrit-select-remote-url-cmd) magit-gerrit-remote))
 
 (defun magit-gerrit-get-project ()
   (let* ((regx (rx (zero-or-one ?:) (zero-or-more (any digit)) ?/


### PR DESCRIPTION
Gerrit setup can be optimized to separate master and slave servers. Previous implementation was using pull-url. This add possibility for user to select push-url for gerrit connection and select which one is faster.