### PR TITLE
Optimize gerrit query cmd by removing comments and approvals

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -132,8 +132,6 @@
 (defun gerrit-query (prj &optional status)
   (gerrit-command "query"
                   "--format=JSON"
-                  "--all-approvals"
-                  "--comments"
                   "--current-patch-set"
                   (concat "project:" prj)
                   (concat magit-gerrit-extra-options)


### PR DESCRIPTION
Remove comments and all-approvals from Gerrit query command parameters. This limits the amount of the transferred data a lot in some usecases.

As an example from one usecase this dropped data size from 11MB to 33K. Removing just "--comments" gave still 200K data.


Not sure if this is ok in all use cases though? 