### PR TITLE
fix quoting for messages

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -657,7 +657,7 @@ Succeed even if branch already exist
     (magit-refresh)))
 
 (defun magit-gerrit-read-comment (&rest _args)
-  (format "\'\"%s\"\'"
+  (format "\'%s\'"
           (read-from-minibuffer "Message: ")))
 
 (transient-define-argument magit-gerrit-message:--message ()


### PR DESCRIPTION
The double quote inside the single quote lead to the effect that messages get double quotes added when they appear at gerrit.