### PR TITLE
defcustom to collapse gerrit patchset section by default

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -111,6 +111,17 @@
   :group 'magit-gerrit
   :type 'string)
 
+(defcustom magit-gerrit-collapse-patchset-section nil
+  "Collapse/hide gerrit section containing patchsets by default.
+Collapse/hide the section body containing the list of gerrit
+changesets by default when t. This only has an effect when
+creating the section for the first time. When the section is
+recreated during a refresh, then the visibility of predecessor is
+inherited and this setting is ignored. See also the HIDE
+parameter of `magit-insert-section'."
+  :group 'magit-gerrit
+  :type 'boolean)
+
 (defcustom magit-gerrit-ellipsis ".."
   "String ellipsis"
   :group 'magit-gerrit
@@ -421,7 +432,7 @@ Succeed even if branch already exist
 (defun magit-gerrit-section (_section title washer &rest args)
   (let ((magit-git-executable "ssh")
         (magit-git-global-arguments nil))
-    (magit-insert-section (section title)
+    (magit-insert-section (section title magit-gerrit-collapse-patchset-section)
       (magit-insert-heading title)
       (insert (magit-gerrit-pretty-print-review-header))
       (magit-git-wash washer (split-string (car args)))


### PR DESCRIPTION
Add a customizable variable to show or collapse the magit section containing the gerrit patchsets.