### PR TITLE
Several improvements

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -86,6 +86,9 @@
 (defvar-local magit-gerrit-force-enable nil
   "Force enabling `magit-gerrit' for the project.")
 
+(defvar-local magit-gerrit-port 29418
+  "The default port to use with the Gerrit host.")
+
 (defcustom magit-gerrit-use-push-url nil
   "If t use push url from 'git remote' for Gerrit connection."
   :group 'magit-gerrit
@@ -137,7 +140,9 @@ parameter of `magit-insert-section'."
 
 (defun gerrit-command (cmd &rest args)
   (let ((gcmd (concat
-               "-x -p 29418 "
+               "-x -p "
+               (number-to-string magit-gerrit-port)
+               " "
                (or magit-gerrit-ssh-creds
                    (error "`magit-gerrit-ssh-creds' must be set!"))
                " "
@@ -764,7 +769,7 @@ Assumes REMOTE-URL is a Gerrit repo if scheme is SSH and port is the
 default Gerrit SSH port."
   (let ((url (url-generic-parse-url remote-url)))
     (when (and (string= "ssh" (url-type url))
-               (eq 29418 (url-port url)))
+               (eq magit-gerrit-port (url-port url)))
       (set (make-local-variable 'magit-gerrit-ssh-creds)
            (format "%s@%s" (url-user url) (url-host url)))
       (message "Detected magit-gerrit-ssh-creds=%s" magit-gerrit-ssh-creds))))

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -83,6 +83,9 @@
 (defvar-local magit-gerrit-remote "origin"
   "Default remote name to use for gerrit (e.g. \"origin\", \"gerrit\")")
 
+(defvar-local magit-gerrit-force-enable nil
+  "Force enabling `magit-gerrit' for the project.")
+
 (defcustom magit-gerrit-use-push-url nil
   "If t use push url from 'git remote' for Gerrit connection."
   :group 'magit-gerrit
@@ -771,10 +774,11 @@ default Gerrit SSH port."
   (defvar magit-origin-action nil)
   (let ((remote-url (magit-gerrit-get-remote-url)))
     (when (and remote-url
-               (or magit-gerrit-ssh-creds
-                   (magit-gerrit-detect-ssh-creds remote-url))
-               (string-match magit-gerrit-ssh-creds remote-url))
-      (magit-gerrit-mode t))
+               (or magit-gerrit-force-enable
+                   (and (or magit-gerrit-ssh-creds
+                            (magit-gerrit-detect-ssh-creds remote-url))
+                        (string-match magit-gerrit-ssh-creds remote-url))))
+      (magit-gerrit-mode 1))
     (if (not magit-origin-action)
         (setf magit-origin-action
               (lookup-key magit-mode-map magit-gerrit-popup-prefix)))

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -249,34 +249,34 @@ Succeed even if branch already exist
                               10
                               nil ?\s magit-gerrit-ellipsis)))
          ;; lastupdate
-        (lastupdate (propertize (truncate-string-to-width
-                               (format "%s" "Updated")
-                                12
-                                nil ?\s magit-gerrit-ellipsis)))
-        ;; approvals
-        (approvals-info (magit-gerrit-create-review-labels))
+         (lastupdate (propertize (truncate-string-to-width
+                                  (format "%s" "Updated")
+                                  12
+                                  nil ?\s magit-gerrit-ellipsis)))
+         ;; approvals
+         (approvals-info (magit-gerrit-create-review-labels))
 
-        ;; subject
-        (subjstr (propertize
-                  (truncate-string-to-width
-                   (format "%s" "Subject")
-                   (- wid (length (concat numstr author
-                                          (cond
-                                           ((> wid 128) (concat branch sizeinfo lastupdate approvals-info))
-                                           ((> wid 108) (concat sizeinfo lastupdate approvals-info))
-                                           ((> wid 94)  (concat sizeinfo approvals-info))
-                                           ((> wid 80)  (concat approvals-info))
-                                           (t ""))))
-                   1)
-                  nil ?\s magit-gerrit-ellipsis)))
+         ;; subject
+         (subjstr (propertize
+                   (truncate-string-to-width
+                    (format "%s" "Subject")
+                    (- wid (length (concat numstr author
+                                           (cond
+                                            ((> wid 128) (concat branch sizeinfo lastupdate approvals-info))
+                                            ((> wid 108) (concat sizeinfo lastupdate approvals-info))
+                                            ((> wid 94)  (concat sizeinfo approvals-info))
+                                            ((> wid 80)  (concat approvals-info))
+                                            (t ""))))
+                       1)
+                    nil ?\s magit-gerrit-ellipsis)))
 
-        (show-str (concat numstr subjstr author
-                          (cond
-                           ((> wid 128) (concat branch sizeinfo lastupdate approvals-info))
-                           ((> wid 108) (concat sizeinfo lastupdate approvals-info))
-                           ((> wid 94)  (concat sizeinfo approvals-info))
-                           ((> wid 80)  (concat approvals-info))
-                           (t "")))))
+         (show-str (concat numstr subjstr author
+                           (cond
+                            ((> wid 128) (concat branch sizeinfo lastupdate approvals-info))
+                            ((> wid 108) (concat sizeinfo lastupdate approvals-info))
+                            ((> wid 94)  (concat sizeinfo approvals-info))
+                            ((> wid 80)  (concat approvals-info))
+                            (t "")))))
     (propertize (format "%s\n" show-str) 'face 'highlight)))
 
 (defun magit-gerrit-pretty-print-review (num patchsetn subj owner-name br size-i size-d ctime approvals-info &optional draft)
@@ -345,8 +345,8 @@ Succeed even if branch already exist
                             ((> wid 94)  (concat sizeinfo approvals-info))
                             ((> wid 80)  (concat approvals-info))
                             (t "")))))
-    (format "%s\n" show-str)
-    ))
+    (format "%s\n" show-str)))
+
 
 (defun magit-gerrit-match-review-labels (score type)
   "Match SCORE to correct TYPE."
@@ -406,8 +406,8 @@ Succeed even if branch already exist
          (approvs (cdr-safe (if (listp patchsets)
                                 (assoc 'approvals patchsets)
                               (assoc 'approvals (aref patchsets 0)))))
-         (scoreinfo (magit-gerrit-wash-approvals-oneline approvs))
-         )
+         (scoreinfo (magit-gerrit-wash-approvals-oneline approvs)))
+
     (if (and beg end)
         (delete-region beg end))
     (when (and num subj owner-name)
@@ -553,7 +553,7 @@ Succeed even if branch already exist
       (list "")))
 
 (defun magit-gerrit-verify-review (args)
-  "Verify a Gerrit Review"
+  "Verify a Gerrit Review."
   (interactive (magit-gerrit-arguments))
 
   (let ((score (completing-read "Score: "
@@ -688,8 +688,7 @@ Succeed even if branch already exist
   :class 'transient-option
   :key "-m"
   :argument "--message "
-  :reader 'magit-gerrit-read-comment
-  )
+  :reader 'magit-gerrit-read-comment)
 
 (defun magit-gerrit-create-branch (_branch _parent))
 
@@ -757,9 +756,9 @@ Succeed even if branch already exist
     (magit-refresh)))
 
 (defun magit-gerrit-detect-ssh-creds (remote-url)
-  "Derive magit-gerrit-ssh-creds from remote-url.
-Assumes remote-url is a gerrit repo if scheme is ssh
-and port is the default gerrit ssh port."
+  "Derive `magit-gerrit-ssh-creds' from REMOTE-URL.
+Assumes REMOTE-URL is a Gerrit repo if scheme is SSH and port is the
+default Gerrit SSH port."
   (let ((url (url-generic-parse-url remote-url)))
     (when (and (string= "ssh" (url-type url))
                (eq 29418 (url-port url)))

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -1,6 +1,6 @@
 ;;; magit-gerrit.el --- Magit plugin for Gerrit Code Review  -*- lexical-binding: t; -*-
 ;;
-;; Copyright (C) 2013 Brian Fransioli
+;; Copyright (C) 2013-2025 Brian Fransioli
 ;;
 ;; Author: Brian Fransioli <assem@terranpro.org>
 ;; URL: https://github.com/terranpro/magit-gerrit
@@ -807,9 +807,11 @@ default Gerrit SSH port."
 ;; Hack in dir-local variables that might be set for magit gerrit
 (add-hook 'magit-status-mode-hook #'hack-dir-local-variables-non-file-buffer t)
 
-;; Try to auto enable magit-gerrit in the magit-status buffer
-(add-hook 'magit-status-mode-hook #'magit-gerrit-check-enable t)
-(add-hook 'magit-log-mode-hook #'magit-gerrit-check-enable t)
+;;;###autoload
+(defun magit-gerrit-auto-enable ()
+  "Try to auto enable magit-gerrit in the `magit-status' buffer."
+  (add-hook 'magit-status-mode-hook #'magit-gerrit-check-enable t)
+  (add-hook 'magit-log-mode-hook #'magit-gerrit-check-enable t))
 
 (provide 'magit-gerrit)
 


### PR DESCRIPTION
In my workflow, I use `repo` to clone a bunch of repos from Gerrit, the remote URLs in this case can be of form `ssh://gerrit.local/xxxx/yyy/zzz` and not `ssh://user@gerrit.local:29418/xxx/yyy/zzz`.

The host configuration in `.ssh/config` can specify the port and username for the host `gerrit.local`, which gives remote access even via `ssh://gerrit.local/xxxx/yyy/zzz`.

However, the condition checked in `magit-gerrit-check-enable` supposes that the URL have the form of `ssh://user@gerrit.local:29418/xxx/yyy/zzz` so it will never work.

This MR tries to solve this by defining the `magit-gerrit-force-enable` buffer-local variable. The idea is to set this variable via `.dir-locals.el` to force enabling `magit-gerrit` for a particular project even if the URL doesn't follow the classic pattern.

This MR also adds a way to customize the port number for the Gerrit server, allowing the user to specify an arbitrary port for non-standard installations.